### PR TITLE
NULL pointer dereference fix

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -175,8 +175,13 @@ filemap_jump_to_offset (struct filemap *map, uint32_t offset)
 void
 filemap_scroll (struct filemap *map, int delta)
 {
-  uint32_t offset = map->offset;
+  uint32_t offset;
     
+  if (!map)
+    return;
+ 
+  offset = map->offset;
+
   if (delta != 0)
   {
     if ((int) offset + delta < 0)

--- a/src/map.c
+++ b/src/map.c
@@ -314,25 +314,26 @@ generic_drag_onmousedown (enum simtk_event_type type,
 	  struct simtk_widget *widget,
 	  struct simtk_event *event)
 {
+  int button = event->button;
+  struct filemap *map = NULL;
 
-  switch (event->button)
-  {
-  case SIMTK_MOUSE_BUTTON_LEFT:
+  if (button == SIMTK_MOUSE_BUTTON_LEFT) {
     drag_flag = 1;
     
     drag_start_x = event->x;
     drag_start_y = event->y;
-    break;
+  } else {
+    map = (struct filemap *) simtk_window_get_opaque (widget);
 
-  case SIMTK_MOUSE_BUTTON_UP:
-    filemap_scroll ((struct filemap *) simtk_window_get_opaque (widget), -1024);
-    break;
-
-  case SIMTK_MOUSE_BUTTON_DOWN:
-    filemap_scroll ((struct filemap *) simtk_window_get_opaque (widget), 1024);
-    break;
+    if (map) {
+      if (button == SIMTK_MOUSE_BUTTON_UP) {
+        filemap_scroll (map, -1024);
+      } else if (button == SIMTK_MOUSE_BUTTON_DOWN) {
+        filemap_scroll (map, 1024);
+      }
+    }
   }
-  
+
   return HOOK_RESUME_CHAIN;
 }
 


### PR DESCRIPTION
It occurs when we scroll while a cursor points to the terminal window.