### PR TITLE
prefixed build install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,5 @@ ACLOCAL_AMFLAGS = -I m4
 
 EXTRA_DIST = AUTHORS ChangeLog NEWS README
 
-datadir=/usr/lib/vix
-dist_data_DATA=background.bmp
-
+dist_pkgdata_DATA=background.bmp
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,3 +8,5 @@ EXTRA_DIST = AUTHORS ChangeLog NEWS README
 
 dist_pkgdata_DATA=background.bmp
 
+install-data-local:
+	$(MKDIR_P) $(pkgdatadir)/scripts

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ if test "${CFLAGS+set}" = set; then
   cflags_were_set=:
 fi
 
+AC_PROG_MKDIR_P
+
 AC_PROG_CC
 AM_PROG_CC_C_O
 AM_PROG_AS

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,7 @@
 
 
 bin_PROGRAMS = vix
+vix_CPPFLAGS = -DVIX_DATA_DIR=\"$(pkgdatadir)\"
 vix_CFLAGS = -I. -I.. -I../util -I../sim-static @GLOBAL_CFLAGS@ @GUILE_CFLAGS@
 vix_LDFLAGS = @GLOBAL_LDFLAGS@
 

--- a/src/vix.h
+++ b/src/vix.h
@@ -38,7 +38,6 @@
 #include <pearl-m68k.h> /* From sim-static: Built-in simulation library over SDL */
 #include <pixel.h> /* From sim-static: Built-in simulation library over SDL */
 
-#define VIX_DATA_DIR    "/usr/lib/vix"
 #define VIX_SCRIPTS_DIR VIX_DATA_DIR "/scripts"
 #define VIX_BG_PATH     VIX_DATA_DIR "/background.bmp"
 


### PR DESCRIPTION
Hi, Thanks for a very neat tool.

I like to install things into a path under my $HOME so I made the tweaks in this changeset.

This changeset removes the "/usr/lib" hardcode. I switched to share from lib also -- it's the default for 'data' according to autoconf -- if you'd rather it stay in 'lib' I can and will tweak the PR quite easily.

As a bonus minor things I added a mkdir of the scripts dir -- there was a warning that it was missing from vix on  a clean install.

Here's what the results of 'make install' look like after a .configure --prefix=$HOME/Applications/vix
```
Applications/vix
├── bin
│   └── vix
└── share
    └── vix
        ├── background.bmp
        └── scripts

4 directories, 2 files
```